### PR TITLE
ブログ記事のCRUD機能に関するコントローラ、ルーティングを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -50,3 +50,7 @@ end
 gem "devise"
 gem "devise_token_auth"
 gem 'devise-i18n'
+gem "carrierwave"
+gem "fog-aws"
+gem "dotenv-rails"
+gem 'active_model_serializers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.14)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (7.0.8)
       activesupport (= 7.0.8)
       globalid (>= 0.3.6)
@@ -66,11 +71,22 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
     bcrypt (3.1.19)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
+    carrierwave (3.0.4)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      ssrf_filter (~> 1.0)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
@@ -90,15 +106,41 @@ GEM
       bcrypt (~> 3.0)
       devise (> 3.5.2, < 5)
       rails (>= 4.2.0, < 7.1)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.12.0)
+    excon (0.104.0)
+    ffi (1.16.3)
+    fog-aws (3.21.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.3.0)
+      builder
+      excon (~> 0.71)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.6.0)
     irb (1.8.1)
       rdoc
       reline (>= 0.3.8)
+    jsonapi-renderer (0.2.2)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -109,9 +151,14 @@ GEM
       net-smtp
     marcel (1.0.2)
     method_source (1.0.0)
+    mime-types (3.5.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.1003)
+    mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mysql2 (0.5.5)
     net-imap (0.4.0)
       date
@@ -138,6 +185,7 @@ GEM
       pry (>= 0.10.4)
     psych (5.1.0)
       stringio
+    public_suffix (5.0.3)
     puma (5.6.7)
       nio4r (~> 2.0)
     racc (1.7.1)
@@ -182,6 +230,9 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
+    ssrf_filter (1.1.2)
     stringio (3.0.8)
     thor (1.2.2)
     timeout (0.4.0)
@@ -199,11 +250,15 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap
+  carrierwave
   debug
   devise
   devise-i18n
   devise_token_auth
+  dotenv-rails
+  fog-aws
   mysql2
   pry-byebug
   pry-rails

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,16 +1,63 @@
 class Api::PostsController < ApplicationController
+  before_action :authenticate_api_user!, only: [:create, :update, :destroy, :my_posts]
+  before_action :find_post, only: [:show, :update, :destroy]
+
   def index
+    @posts = Post.includes(:user).all
+    render json: @posts, include: [:user]
   end
 
   def create
+    @post = current_api_user.posts.new(post_params)
+
+    if @post.save
+      render json: @post, status: :created
+    else
+      render json: @post.errors, status: :unprocessable_entity
+    end
   end
 
   def show
+    render json: @post, serializer: PostSerializer, include: [:user]
   end
 
   def update
+    if @post.update(post_params)
+      render json: @post, status: :created
+    else
+      render json: @post.errors, status: :unprocessable_entity
+    end
   end
 
   def destroy
+    @post.destroy
+    head :no_content
+  end
+
+  def index_for_blogs
+    @users = User.includes(:posts).all
+    render json: @users, include: [:posts]
+  end
+
+  def index_by_user
+    user_id = params[:user_id]
+
+    @posts = Post.where(user_id: user_id)
+    render json: @posts, each_serializer: PostSerializer
+  end
+
+  def my_posts
+    @posts = current_api_user.posts
+    render json: @posts
+  end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:title, :body, :image)
+  end
+
+  def find_post
+    @post = Post.find(params[:id])
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,3 +1,4 @@
 class Post < ApplicationRecord
   belongs_to :user
+  mount_uploader :image, ImageUploader
 end

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -1,0 +1,9 @@
+class PostSerializer < ActiveModel::Serializer
+  attributes :id, :title, :body, :image, :created_at_formatted
+
+  belongs_to :user
+
+  def created_at_formatted
+    object.created_at.strftime('%Y/%m/%d %H:%M')
+  end
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,47 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  # storage :file
+  storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,8 @@ module BlogAppBack
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
+    config.time_zone = 'Tokyo'
+
     config.session_store :cookie_store, key: '_interslice_session'
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use ActionDispatch::Session::CookieStore, config.session_options

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,18 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = 'shomacafe-blog-app'
+    config.fog_public = false
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/shomacafe-blog-app'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region: 'ap-northeast-1',
+      path_style: true
+    }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,12 @@ Rails.application.routes.draw do
       resources :sessions, only: %i[index]
     end
 
-    resources :posts, only: [:index, :show, :create, :update, :destroy]
+    resources :posts, only: [:index, :show, :create, :update, :destroy] do
+      collection do
+        get 'blogs', to: 'posts#index_for_blogs'
+        get :index_by_user
+        get :my_posts
+      end
+    end
   end
 end


### PR DESCRIPTION
### 【実装内容】
ブログ記事のCRUD機能を実装しました。
また、
・ブログ一覧
・特定のユーザーが投稿したブログ記事一覧
・自分が投稿したブログ記事一覧
のエンドポイントも追加しました。

- 全てのブログの取得
GET /api/posts/blogs
- 特定のブログ記事を取得
GET /api/posts/{post_id}
- ブログ記事の作成
POST /api/posts
- 特定のブログ記事の更新
PUT /api/posts/{post_id}
- 特定のブログ記事の削除
DELETE /api/posts/{post_id}
- 特定のユーザーが投稿したブログ記事の取得
GET /api/posts/users/{user_id}
- 自分が投稿したブログ記事の取得
GET /api/posts/my_posts