### PR TITLE
特定のブログ記事をお気に入り登録できるようFavoritesコントローラを追加

### DIFF
--- a/app/controllers/api/favorites_controller.rb
+++ b/app/controllers/api/favorites_controller.rb
@@ -1,0 +1,41 @@
+class Api::FavoritesController < ApplicationController
+  before_action :authenticate_api_user!, only: [:index, :create, :destroy]
+
+  def index
+  end
+
+  def favorite_status
+    user_id = params[:user_id]
+    post = Post.includes(:favorites).find(params[:id])
+    is_favorite = Favorite.exists?(user_id, post.id)
+    render json: { is_favorite: is_favorite }
+  end
+
+  def create
+    post = Post.find(params[:post_id])
+
+    if current_api_user.id == post.user.id
+      render json: { error: '自分の投稿にはお気に入り登録できません' }, status: :unprocessable_entity
+      return
+    end
+
+    @favorite = current_api_user.favorites.build(post_id: params[:post_id])
+
+    if @favorite.save
+      render json: @favorite, status: :created
+    else
+      render json: @favorite.errors, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @favorite = current_api_user.favorites.find_by(post_id: params[:id])
+
+    if @favorite
+      @favorite.destroy
+      head :no_content
+    else
+      render json: { error: 'お気に入りが見つかりません' }, status: :not_found
+    end
+  end
+end

--- a/app/controllers/api/favorites_controller.rb
+++ b/app/controllers/api/favorites_controller.rb
@@ -1,16 +1,6 @@
 class Api::FavoritesController < ApplicationController
   before_action :authenticate_api_user!, only: [:index, :create, :destroy]
 
-  def index
-  end
-
-  def favorite_status
-    user_id = params[:user_id]
-    post = Post.includes(:favorites).find(params[:id])
-    is_favorite = Favorite.exists?(user_id, post.id)
-    render json: { is_favorite: is_favorite }
-  end
-
   def create
     post = Post.find(params[:post_id])
 
@@ -37,5 +27,20 @@ class Api::FavoritesController < ApplicationController
     else
       render json: { error: 'お気に入りが見つかりません' }, status: :not_found
     end
+  end
+
+  def favorite_posts
+    favorite_post_ids = current_api_user.favorites.pluck(:post_id)
+
+    @favorite_posts = Post.where(id: favorite_post_ids)
+
+    render json: @favorite_posts, status: :ok
+  end
+
+  def favorite_status
+    user_id = params[:user_id]
+    post = Post.includes(:favorites).find(params[:id])
+    is_favorite = Favorite.exists?(user_id, post.id)
+    render json: { is_favorite: is_favorite }
   end
 end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,0 +1,8 @@
+class Api::UsersController < ApplicationController
+  before_action :authenticate_api_user!
+
+  def show
+    @user = User.find(params[:id])
+    render json: @user
+  end
+end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,10 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+
+  validates_uniqueness_of :post_id, scope: :user_id
+
+  def self.exists?(user_id, post_id)
+    where(user_id: user_id, post_id: post_id).exists?
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,6 @@
 class Post < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
+  has_many :favorites, dependent: :destroy
   mount_uploader :image, ImageUploader
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@
 class User < ActiveRecord::Base
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :favorites, dependent: :destroy
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -3,6 +3,7 @@ class PostSerializer < ActiveModel::Serializer
 
   belongs_to :user
   has_many :comments, serializer: CommentSerializer
+  has_many :favorites
 
   def created_at_formatted
     object.created_at.strftime('%Y/%m/%d %H:%M')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
   namespace :api do
+    get 'favorites/index'
+    get 'favorites/create'
+    get 'favorites/destroy'
     get 'comments/create'
     get 'comments/update'
     get 'comments/destroy'
@@ -17,7 +20,13 @@ Rails.application.routes.draw do
         get :index_by_user
         get :my_posts
       end
+      member do
+        post 'favorite', to: 'favorites#create'
+        delete 'unfavorite', to: 'favorites#destroy'
+      end
       resources :comments, only: [:create, :update, :destroy]
     end
+
+    get '/posts/:id/favorite_status', to: 'favorites#favorite_status'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,5 @@
 Rails.application.routes.draw do
   namespace :api do
-    get 'favorites/index'
-    get 'favorites/create'
-    get 'favorites/destroy'
-    get 'comments/create'
-    get 'comments/update'
-    get 'comments/destroy'
     mount_devise_token_auth_for 'User', at: 'auth', controllers: {
       registrations: 'api/auth/registrations'
     }
@@ -19,14 +13,14 @@ Rails.application.routes.draw do
         get 'blogs', to: 'posts#index_for_blogs'
         get :index_by_user
         get :my_posts
+        get 'favorite_posts', to: 'favorites#favorite_posts'
       end
       member do
         post 'favorite', to: 'favorites#create'
         delete 'unfavorite', to: 'favorites#destroy'
+        get 'favorite_status', to: 'favorites#favorite_status'
       end
       resources :comments, only: [:create, :update, :destroy]
     end
-
-    get '/posts/:id/favorite_status', to: 'favorites#favorite_status'
   end
 end

--- a/db/migrate/20231013141945_create_favorites.rb
+++ b/db/migrate/20231013141945_create_favorites.rb
@@ -1,0 +1,10 @@
+class CreateFavorites < ActiveRecord::Migration[7.0]
+  def change
+    create_table :favorites do |t|
+      t.references :user, foreign_key: true, null: false
+      t.references :post, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_12_125224) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_13_141945) do
   create_table "comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "post_id", null: false
@@ -19,6 +19,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_12_125224) do
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "favorites", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_favorites_on_post_id"
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
   create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -59,5 +68,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_12_125224) do
 
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
+  add_foreign_key "favorites", "posts"
+  add_foreign_key "favorites", "users"
   add_foreign_key "posts", "users"
 end

--- a/test/controllers/api/favorites_controller_test.rb
+++ b/test/controllers/api/favorites_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class Api::FavoritesControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get api_favorites_index_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get api_favorites_create_url
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get api_favorites_destroy_url
+    assert_response :success
+  end
+end

--- a/test/controllers/api/users_controller_test.rb
+++ b/test/controllers/api/users_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class Api::UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get api_users_show_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/favorites.yml
+++ b/test/fixtures/favorites.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/favorite_test.rb
+++ b/test/models/favorite_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FavoriteTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 【実装内容】

- ブログ記事詳細画面でお気に入り登録、解除するcreate、destroyアクション
- 登録しているか確認するためのfavorite_statusアクション
- お気に入り登録した記事一覧を渡すfavorite_postsアクション

を追加しました。