### PR TITLE
プロフィールの編集に関するコントローラ追加/バリデーションの追加

### DIFF
--- a/app/controllers/api/favorites_controller.rb
+++ b/app/controllers/api/favorites_controller.rb
@@ -1,5 +1,5 @@
 class Api::FavoritesController < ApplicationController
-  before_action :authenticate_api_user!, only: [:index, :create, :destroy]
+  before_action :authenticate_api_user!, only: [:index, :create, :destroy, :favorite_posts, :favorite_status]
 
   def create
     post = Post.find(params[:post_id])

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -35,7 +35,7 @@ class Api::PostsController < ApplicationController
   end
 
   def index_for_blogs
-    @users = User.includes(:posts).all
+    @users = User.joins(:posts).distinct
     render json: @users, include: [:posts]
   end
 

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -5,4 +5,42 @@ class Api::UsersController < ApplicationController
     @user = User.find(params[:id])
     render json: @user
   end
+
+  def update_profile
+    @user = current_api_user
+
+    if @user.update(profile_params)
+      render json: @user
+    else
+      render json: { errors: @user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update_account
+    @user = current_api_user
+
+    if params[:email].present?
+      unless @user.valid_password?(params[:current_password])
+        render json: { errors: ['現在のパスワードが正しくありません'] }, status: :unprocessable_entity
+        return
+      end
+    end
+
+    if @user.update(account_params)
+      render json: @user
+    else
+      render json: { errors: @user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def profile_params
+    params.require(:user).permit(:name, :image, :profile)
+  end
+
+  def account_params
+    params.permit(:email, :password, :password_confirmation)
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,11 @@
 class ApplicationController < ActionController::Base
-        include DeviseTokenAuth::Concerns::SetUserByToken
-        include ActionController::Cookies
+  include DeviseTokenAuth::Concerns::SetUserByToken
+  include ActionController::Cookies
 
-        skip_before_action :verify_authenticity_token
-        helper_method :current_user, :user_signed_in?
-      end
+  before_action do
+    I18n.locale = :ja
+  end
+
+  skip_before_action :verify_authenticity_token
+  helper_method :current_user, :user_signed_in?
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post
+
+  validates :body, presence: true, length: {maximum: 500, message: "コメントは500文字以内で入力してください"}
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,4 +3,7 @@ class Post < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :favorites, dependent: :destroy
   mount_uploader :image, ImageUploader
+
+  validates :title, presence: true, length: {maximum: 50, message: "タイトルは50文字以内で入力してください" }
+  validates :body, presence: true, length: {maximum: 5000, message: "本文は5000文字以内で入力してください"}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,10 +4,14 @@ class User < ActiveRecord::Base
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :favorites, dependent: :destroy
+  mount_uploader :image, ImageUploader
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
+
+  validates :name, presence: true, length: {maximum: 30 }
+  validates :profile, length: {maximum: 300 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,12 @@ class User < ActiveRecord::Base
   has_many :favorites, dependent: :destroy
   mount_uploader :image, ImageUploader
 
+  before_validation :set_default_profile
+
+  def set_default_profile
+    self.profile ||= "#{self.name}です。よろしくお願いします。"
+  end
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,7 @@ module BlogAppBack
     config.api_only = true
 
     config.time_zone = 'Tokyo'
+    config.i18n.default_locale = :ja
 
     config.session_store :cookie_store, key: '_interslice_session'
     config.middleware.use ActionDispatch::Cookies

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,101 @@
+ja:
+  errors:
+    messages:
+      not_found: "が見つかりません"
+      already_confirmed: "はすでに確認済みです。サインインを試してみてください。"
+      confirmation_period_expired: "%{period}以内に確認する必要があります。新しい確認をリクエストしてください。"
+      expired: "期限切れです。新しい確認をリクエストしてください。"
+      confirmation: "がパスワードと一致しません"
+      invalid: "は有効ではありません"
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            name:
+              too_long: "は%{count}文字以下で入力してください。"
+              blank: "が入力されていません。"
+            profile:
+              too_long: "は%{count}文字以下で入力してください。"
+            email:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上で入力してください。"
+              too_long: "は%{count}文字以下で入力してください。"
+              invalid: "は有効でありません。"
+            password:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上で入力してください。"
+              too_long: "は%{count}文字以下で入力してください。"
+              invalid: "は有効でありません。"
+              confirmation: "が内容とあっていません。"
+            password_confirmation:
+              confirmation: "がパスワードと一致しません"
+    attributes:
+      user:
+        current_password: "現在のパスワード"
+        name: 名前
+        profile: プロフィール
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "確認用パスワード"
+        remember_me: "次回から自動的にログイン"
+    models:
+      user: "ユーザ"
+  devise:
+    confirmations:
+      new:
+        resend_confirmation_instructions: "アカウント確認メール再送"
+    mailer:
+      confirmation_instructions:
+        action: "アカウント確認"
+        greeting: "ようこそ、%{recipient}さん!"
+        instruction: "次のリンクでメールアドレスの確認が完了します:"
+      reset_password_instructions:
+        action: "パスワード変更"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "誰かがパスワードの再設定を希望しました。次のリンクでパスワードの再設定が出来ます。"
+        instruction_2: "あなたが希望したのではないのなら、このメールは無視してください。"
+        instruction_3: "上のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。"
+      unlock_instructions:
+        action: "アカウントのロック解除"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "アカウントのロックを解除するには下のリンクをクリックしてください。"
+        message: "ログイン失敗が繰り返されたため、アカウントはロックされています。"
+    passwords:
+      edit:
+        change_my_password: "パスワードを変更する"
+        change_your_password: "パスワードを変更"
+        confirm_new_password: "確認用新しいパスワード"
+        new_password: "新しいパスワード"
+      new:
+        forgot_your_password: "パスワードを忘れましたか?"
+        send_me_reset_password_instructions: "パスワードの再設定方法を送信する"
+    registrations:
+      edit:
+        are_you_sure: "本当に良いですか?"
+        cancel_my_account: "アカウント削除"
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: "空欄のままなら変更しません"
+        title: "%{resource}編集"
+        unhappy: "気に入りません"
+        update: "更新"
+        we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
+      new:
+        sign_up: "アカウント登録"
+    sessions:
+      new:
+        sign_in: "ログイン"
+    shared:
+      links:
+        back: "戻る"
+        didn_t_receive_confirmation_instructions: "アカウント確認のメールを受け取っていませんか?"
+        didn_t_receive_unlock_instructions: "アカウントの凍結解除方法のメールを受け取っていませんか?"
+        forgot_your_password: "パスワードを忘れましたか?"
+        sign_in: "ログイン"
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: "アカウント登録"
+    unlocks:
+      new:
+        resend_unlock_instructions: "アカウントの凍結解除方法を再送する"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,11 @@ Rails.application.routes.draw do
       end
       resources :comments, only: [:create, :update, :destroy]
     end
+    resources :users, only: [:show] do
+      collection do
+        put 'profile', to: 'users#update_profile'
+        put 'account', to: 'users#update_account'
+      end
+    end
   end
 end


### PR DESCRIPTION
### 【実装内容】

- プロフィールの編集に関するコントローラの追加

アカウント（メールアドレスとパスワード）とプロフィール（名前とプロフィール）をそれぞれの画面で編集できるよう、
PUT    /api/users/account
PUT    /api/users/profile
というエンドポイントを用意しました。

- バリデーションの追加

deviseのデフォルトのエラー文が英語だったので、日本語で表示されるように設定しました。